### PR TITLE
Adding BayesianTracker

### DIFF
--- a/cellst/config/bayes_config.json
+++ b/cellst/config/bayes_config.json
@@ -1,0 +1,68 @@
+{
+  "TrackerConfig":
+    {
+      "MotionModel":
+        {
+          "name": "cell_motion",
+          "dt": 1.0,
+          "measurements": 3,
+          "states": 6,
+          "accuracy": 7.5,
+          "prob_not_assign": 0.001,
+          "max_lost": 5,
+          "A": {
+            "matrix": [1,0,0,1,0,0,
+                       0,1,0,0,1,0,
+                       0,0,1,0,0,1,
+                       0,0,0,1,0,0,
+                       0,0,0,0,1,0,
+                       0,0,0,0,0,1]
+          },
+          "H": {
+            "matrix": [1,0,0,0,0,0,
+                       0,1,0,0,0,0,
+                       0,0,1,0,0,0]
+          },
+          "P": {
+            "sigma": 150.0,
+            "matrix": [0.1,0,0,0,0,0,
+                       0,0.1,0,0,0,0,
+                       0,0,0.1,0,0,0,
+                       0,0,0,1,0,0,
+                       0,0,0,0,1,0,
+                       0,0,0,0,0,1]
+          },
+          "G": {
+            "sigma": 15.0,
+            "matrix": [0.5,0.5,0.5,1,1,1]
+
+          },
+          "R": {
+            "sigma": 5.0,
+            "matrix": [1,0,0,
+                       0,1,0,
+                       0,0,1]
+          }
+        },
+      "ObjectModel":
+        {},
+      "HypothesisModel":
+        {
+          "name": "cell_hypothesis",
+          "hypotheses": ["P_FP", "P_init", "P_term", "P_link", "P_branch", "P_dead"],
+          "lambda_time": 5.0,
+          "lambda_dist": 3.0,
+          "lambda_link": 5.0,
+          "lambda_branch": 5.0,
+          "eta": 1e-10,
+          "theta_dist": 20.0,
+          "theta_time": 5.0,
+          "dist_thresh": 40,
+          "time_thresh": 2,
+          "apop_thresh": 5,
+          "segmentation_miss_rate": 0.1,
+          "apoptosis_rate": 0.001,
+          "relax": true
+        }
+    }
+}

--- a/cellst/config/bayes_config_2d.json
+++ b/cellst/config/bayes_config_2d.json
@@ -1,0 +1,66 @@
+{
+  "TrackerConfig":
+    {
+      "MotionModel":
+        {
+          "name": "cell_motion_2d_sj",
+          "dt": 1.0,
+          "measurements": 3,
+          "states": 6,
+          "accuracy": 7.5,
+          "prob_not_assign": 0.001,
+          "max_lost": 4,
+          "A": {
+            "matrix": [1,0,0,1,0,0,
+                       0,1,0,0,1,0,
+                       0,0,0,0,0,0,
+                       0,0,0,1,0,0,
+                       0,0,0,0,1,0,
+                       0,0,0,0,0,0]
+          },
+          "H": {
+            "matrix": [1,0,0,0,0,0,
+                       0,1,0,0,0,0,
+                       0,0,0,0,0,0]
+          },
+          "P": {
+            "sigma": 150.0,
+            "matrix": [0.1,0,0,0,0,0,
+                       0,0.1,0,0,0,0,
+                       0,0,0,0,0,0,
+                       0,0,0,1,0,0,
+                       0,0,0,0,1,0,
+                       0,0,0,0,0,0]
+          },
+          "G": {
+            "sigma": 15.0,
+            "matrix": [0.5,0.5,0,1,1,0]
+
+          },
+          "R": {
+            "sigma": 5.0,
+            "matrix": [1,0,0,
+                       0,1,0,
+                       0,0,1]
+          }
+        },
+      "ObjectModel":
+        {},
+      "HypothesisModel":
+        {
+          "name": "cell_hypothesis",
+          "hypotheses": ["P_FP", "P_init", "P_term", "P_link", "P_branch"],
+          "lambda_time": 5.0,
+          "lambda_dist": 3.0,
+          "lambda_link": 5.0,
+          "lambda_branch": 10.0,
+          "eta": 1e-10,
+          "theta_dist": 20.0,
+          "theta_time": 5.0,
+          "dist_thresh": 25,
+          "time_thresh": 4,
+          "segmentation_miss_rate": 0.015,
+          "relax": true
+        }
+    }
+}

--- a/cellst/operation.py
+++ b/cellst/operation.py
@@ -593,6 +593,13 @@ class BaseExtract(Operation):
         else:
             self.input_tracks = input_tracks
 
+
+        if isinstance(regions, str):
+            regions = [regions]
+        if isinstance(channels, str):
+            channels = [channels]
+
+
         if len(channels) == 0:
             channels = input_images
 

--- a/cellst/orchestrator.py
+++ b/cellst/orchestrator.py
@@ -50,7 +50,8 @@ class Orchestrator():
                  overwrite: bool = True,
                  log_file: bool = True,
                  save_master_df: bool = True,
-                 job_controller: JobController = None
+                 job_controller: JobController = None,
+                 verbose: bool = True,
                  ) -> None:
         """
         Args:
@@ -74,8 +75,9 @@ class Orchestrator():
         self._set_all_paths(yaml_folder, parent_folder, output_folder)
         self._make_output_folder(self.overwrite)
         if log_file:
+            lev = 'info' if verbose else 'warning'
             self.logger = get_logger(self.__name__, self.output_folder,
-                                     overwrite=overwrite, console_level='info')
+                                     overwrite=overwrite, console_level=lev)
         else:
             self.logger = get_console_logger()
 

--- a/cellst/orchestrator.py
+++ b/cellst/orchestrator.py
@@ -6,7 +6,6 @@ import warnings
 from multiprocessing import Pool
 from typing import Dict, Collection
 from glob import glob
-from pprint import pp
 
 from cellst.operation import Operation
 from cellst.pipeline import Pipeline
@@ -121,6 +120,7 @@ class Orchestrator():
         else:
             results = []
             for fol, kwargs in self.pipelines.items():
+                self.logger.info(f'Starting Pipeline {fol}')
                 results.append(Pipeline._run_single_pipe(kwargs))
 
         if self.save:

--- a/cellst/pipeline.py
+++ b/cellst/pipeline.py
@@ -116,9 +116,6 @@ class Pipeline():
         # Log time spent after enter
         try:
             self.logger.info(f'Total execution time: {time.time() - self.timer}')
-
-            # TODO: Can duplicate logger streams be removed here
-
             self.timer = None
         except TypeError:
             # KeyboardInterrupt now won't cause additional exceptions
@@ -621,8 +618,7 @@ class Pipeline():
               else should be handled externally.
         """
         pipe = cls._build_from_dict(pipe_dict)
-        with pipe:
-            result = pipe.run()
+        result = pipe.run()
 
         # Remove from memory
         del pipe

--- a/cellst/pipeline.py
+++ b/cellst/pipeline.py
@@ -5,7 +5,6 @@ import yaml
 import warnings
 import time
 import shutil
-from pprint import pp
 from typing import Dict, List, Collection, Tuple
 
 import numpy as np

--- a/cellst/pipeline.py
+++ b/cellst/pipeline.py
@@ -49,6 +49,7 @@ class Pipeline():
                  overwrite: bool = True,
                  log_file: bool = True,
                  yaml_path: str = None,
+                 verbose: bool = False,
                  _split_key: str = '&'
                  ) -> None:
         """
@@ -77,8 +78,9 @@ class Pipeline():
 
         # Set up logger - defaults to output folder
         if log_file:
+            lev = 'info' if verbose else 'warning'
             self.logger = get_logger(self.__name__, self.output_folder,
-                                     overwrite=overwrite)
+                                     overwrite=overwrite, console_level=lev)
         else:
             self.logger = get_console_logger()
 

--- a/cellst/segment.py
+++ b/cellst/segment.py
@@ -289,15 +289,21 @@ class Segment(BaseSegment):
     def find_boundaries(self,
                         mask: Mask,
                         connectivity: int = 2,
-                        mode: str = 'inner'
+                        mode: str = 'inner',
+                        binary: bool = False
                         ) -> Mask:
         """
         Outlines the objects in mask and preserves labels.
+
+        if binary - don't preserve labels
         """
         boundaries = find_boundaries(mask, connectivity=connectivity,
                                      mode=mode)
 
-        return np.where(boundaries, mask, 0)
+        if binary:
+            return boundaries
+        else:
+            return np.where(boundaries, mask, 0)
 
     @ImageHelper(by_frame=True)
     def dilate_to_cytoring_celltk(self,

--- a/cellst/track.py
+++ b/cellst/track.py
@@ -71,7 +71,7 @@ class Track(BaseTrack):
     @ImageHelper(by_frame=False)
     def simple_bayesian_track(self,
                               mask: Mask,
-                              config_path: str = 'bayes_config_2d.json',
+                              config_path: str = 'bayes_config.json',
                               update_method: str = 'exact',
                               ) -> Track:
         """

--- a/cellst/utils/bayes_utils.py
+++ b/cellst/utils/bayes_utils.py
@@ -1,0 +1,45 @@
+import numpy as np
+import btrack
+
+from cellst.utils._types import Mask
+
+
+def bayes_update_mask(mask: Mask, objects: list) -> np.ndarray:
+    """
+    Change labels in mask to match ID given in objects
+
+    btrack 0-indexes labels, so background value has to be changed
+    So background will be -1
+
+    Assume that regionprops goes through labels in order
+    """
+    out = np.ones(mask.shape, dtype=np.int16) * -1
+    # Iterate through all frames in mask
+    for t, frame in enumerate(mask):
+        old_labels = np.unique(frame[frame > 0])
+        obs = [o.ID for o in objects
+               if o.t == t and not o.dummy]
+
+        assert len(old_labels) == len(obs)
+
+        for old, new in zip(old_labels, obs):
+            out[t, ...][frame == old] = new
+
+    return out
+
+
+def bayes_extract_tracker_data(mask: Mask,
+                               tracker: btrack.BayesianTracker
+                               ) -> Mask:
+    """
+    Update labels in mask to match the tracker references
+
+    TODO:
+        - This function seems surprisingly slow
+    """
+    out = np.zeros_like(mask)
+    for btrk, bref in zip(tracker.tracks, tracker.refs):
+        trk_obs = np.isin(mask, [b for b in bref if b >= 0])
+        out[trk_obs] = btrk['ID']
+
+    return out

--- a/cellst/utils/slurm_utils.py
+++ b/cellst/utils/slurm_utils.py
@@ -3,7 +3,6 @@ import logging
 import os
 from time import sleep
 from typing import Collection, Generator, List
-from pprint import pp
 
 from cellst.utils.log_utils import get_console_logger
 from cellst.pipeline import Pipeline

--- a/cellst/utils/unet_model.py
+++ b/cellst/utils/unet_model.py
@@ -153,9 +153,11 @@ class UNetModel():
 
         if not all(a == 0 for a in axes_deltas):
             # Divide by two because padding both sides
-            pads = [int(a / 2.) for a in axes_deltas]
+            pads = [int(a / 2) for a in axes_deltas]
+
             # Adjust for odds
-            pads = [(p, p + 1) if p % 2 else (p, p) for p in pads]
+            pads = [(p, p + 1) if a % 2 else (p, p)
+                    for (a, p) in zip(axes_deltas, pads)]
         else:
             pads = [(0, 0) * len(axes_deltas)]
 

--- a/cellst/utils/utils.py
+++ b/cellst/utils/utils.py
@@ -186,6 +186,10 @@ class ImageHelper():
         """
         This func is for sorting the input types and selecting the correct
         types that should get passed to the function.
+
+        TODO:
+            - This could be changed to allow different orders of img, msk, trk, etc.
+              This would allow certain functions to say, require mask, but have image optional
         """
         # First check if user specified names
         img_container, kwargs = self._name_helper(img_container, **kwargs)


### PR DESCRIPTION
This PR is mainly to include a new tracking method from: [https://github.com/quantumjot/BayesianTracker](https://github.com/quantumjot/BayesianTracker)

The method should work okay but will probably require a new config file and/or an object model. In particular, I think the object model could be very helpful. 

One note for future improvements: `bayes_extract_tracker_data()` is easily the bottle neck in this function. It uses `np.isin()`, which I'm pretty sure runs in linear time, `O(n)`. There has to be a faster way to accomplish what I want, possibly
by using `numba.njit`. See [here](https://stackoverflow.com/questions/56120273/quicker-way-to-implement-numpy-isin-followed-by-sum) for a somewhat related answer. Though I need the indices of the located values, not just the values themselves, so those answers might not be applicable.

Minor change: 
    - Adds `verbose` option to `Pipeline` and `Orchestrator`


