### PR TITLE
Improvements for submitting jobs to SLURM

### DIFF
--- a/cellst/__init__.py
+++ b/cellst/__init__.py
@@ -22,3 +22,4 @@ of utils is warranted. Hopefully I can get around to that tonight.
 from .utils import _types as cst_types
 from .utils._types import Image, Mask, Track, Arr, Same
 from .utils._types import Condition, Experiment
+from .utils.slurm_utils import SlurmController

--- a/cellst/extract.py
+++ b/cellst/extract.py
@@ -19,6 +19,7 @@ class Extract(BaseExtract):
                                 regions: Collection[str] = [],
                                 lineages: Collection[np.ndarray] = [],
                                 condition: str = 'default',
+                                position_id: int = None,
                                 min_trace_length: int = 0,
                                 remove_parent: bool = True,
                                 parent_track: int = 0
@@ -104,7 +105,7 @@ class Extract(BaseExtract):
 
         # Initialize data structure
         array = Condition(regions, channels, all_measures, cells, frames,
-                          name=condition)
+                          name=condition, pos_id=position_id)
 
         # Extract data for all channels and regions individually
         for c_idx, cnl in enumerate(channels):
@@ -131,5 +132,4 @@ class Extract(BaseExtract):
         mask = array.remove_short_traces(min_trace_length)
         array.filter_cells(mask, delete=True)
 
-        # Does not need to return type to Extract.run_operation
         return array

--- a/cellst/operation.py
+++ b/cellst/operation.py
@@ -568,6 +568,7 @@ class BaseExtract(Operation):
                  regions: Collection[str] = [],
                  lineages: Collection[np.ndarray] = [],
                  condition: str = '',
+                 position_id: int = None,
                  min_trace_length: int = 0,
                  remove_parent: bool = True,
                  output: str = 'data_frame',
@@ -623,7 +624,7 @@ class BaseExtract(Operation):
         # These kwargs get passed to self.extract_data_from_image
         kwargs = dict(channels=channels, regions=regions, lineages=lineages,
                       condition=condition, min_trace_length=min_trace_length,
-                      remove_parent=remove_parent)
+                      remove_parent=remove_parent, position_id=position_id)
         # Automatically add extract_data_from_image
         # Name is always None, because gets saved in Pipeline as output
         self.functions = [tuple(['extract_data_from_image', None, [], kwargs, None])]

--- a/cellst/utils/slurm_utils.py
+++ b/cellst/utils/slurm_utils.py
@@ -179,7 +179,7 @@ class SlurmController(JobController):
         print('\n ')
 
         user_options = dict(c='continue', q='quit', s='status', r='rerun',
-                            i='info', l='logs', e='error')
+                            i='info', l='logs', h='help')
         for k, v in user_options.items():
             print(f'{k}: {v} \n')
 
@@ -269,9 +269,9 @@ class SlurmController(JobController):
                             pass
                     if jobs:
                         pprint(self._get_slurm_logs_from_jobs(jobs))
-            elif command in ('e', 'error'):
-                # Show error information from slurm logs
-                pass
+            elif command in ('h', 'help'):
+                for k, v in user_options.items():
+                    print(f'{k}: {v} \n')
             else:
                 print(f'Did not understand input {command}... \n')
 


### PR DESCRIPTION
This PR is primarily focused on increasing the usability of the `SlurmController` in a real-world setting (i.e. Sherlock). There are two main changes for this:

1. `Orchestrator` tries to come up with unique position identifiers for duplicate conditions. It defaults to the last part of the name used to save the site. For example. A5-Site_0 and A5-Site_1 both have condition 'Control'. In `Orchestrator`, the `Pipelines` will be saved as 'Control0' and 'Control1' respectively. These are also the names they will have when loaded as a `Condition`. They will also have an additional metric called `position_id` to facilitate finding the cells physically if needed. When loaded by `Experiment`, those two `Conditions` will be combined along the cell axis and saved under the key `Control`. If the folder names do not follow the format above, I doubt this will work well. Also, worth noting that `position_id` must be numeric, otherwise `Condition._arr` would have dtype `object`.
2. A `SignalHandler` class was added to the `JobController` class. This class uses `signal` to catch `SIGINT`, normally raised by pressing `CTRL + C`. When this happens, it opens a very basic interface that the user can utilize to display more information about jobs, rerun jobs, and quit the pipeline. 