### PR TITLE
v0.1.0 patch

### DIFF
--- a/cellst/core/arrays.py
+++ b/cellst/core/arrays.py
@@ -11,6 +11,7 @@ import plotly.graph_objects as go
 import cellst.utils.filter_utils as filt
 from cellst.utils.plot_utils import plot_groups
 from cellst.utils.info_utils import nan_helper_2d
+import cellst.utils.filter_utils as filtu
 from cellst.utils.unet_model import UPeakModel
 from cellst.utils.upeak.peak_utils import segment_peaks_agglomeration
 from cellst.utils.metric_utils import active_cells, cumulative_active
@@ -624,8 +625,8 @@ class ConditionArray():
                 if idx:
                     user_mask[:, idx] = True
 
-                mask = getattr(filt, function)(vals, mask=user_mask,
-                                               *args, **kwargs)
+                mask = getattr(filtu, function)(vals, mask=user_mask,
+                                                *args, **kwargs)
             except AttributeError:
                 raise AttributeError('Did not understand filtering '
                                      f'function {function}.')
@@ -1020,6 +1021,7 @@ class ExperimentArray():
                       channel: [str, int] = 0,
                       frame_rng: (Tuple[int], int) = None,
                       key: str = None,
+                      individual: bool = True,
                       *args, **kwargs
                       ) -> np.ndarray:
         """Generates a boolean mask for each Condition
@@ -1135,6 +1137,7 @@ class ExperimentArray():
                     # Skip merging for these conditions
                     continue
 
+                # Need to add position ID to keep unique identification
                 if len(set([c.pos_id for c in cond_arrs])) < len(cond_arrs):
                     for n, c in enumerate(cond_arrs):
                         # Try to guess pos_id, or just count

--- a/cellst/core/arrays.py
+++ b/cellst/core/arrays.py
@@ -878,6 +878,10 @@ class ExperimentArray():
     def time(self):
         return [v.time for v in self.sites.values()]
 
+    @property
+    def coordinates(self):
+        return tuple(next(iter(self.values())).coords.keys())
+
     def items(self):
         return self.sites.items()
 
@@ -1083,6 +1087,11 @@ class ExperimentArray():
                for msk, arr in zip(mask, self.sites.values())]
 
         return out
+
+    def add_metric_slots(self, name: List[str]) -> None:
+        """"""
+        for v in self.sites.values():
+            v.add_metric_slots(name)
 
     def merge_conditions(self) -> None:
         """

--- a/cellst/core/arrays.py
+++ b/cellst/core/arrays.py
@@ -1155,15 +1155,16 @@ class ExperimentArray():
                     [c.set_position_id() for c in cond_arrs]
 
                 # cells are always indexed by integer, so make new list
-                coords['cells'] = range(sum((len(c.coords['cells'])
-                                             for c in cond_arrs)))
+                coords['cells'] = np.arange(sum((len(c.coords['cells'])
+                                            for c in cond_arrs)))
 
                 # Concatenate the arrays along cell axis
                 ax = cond_arrs[0]._dim_idxs['cells']
                 new_arr = np.concatenate([c._arr for c in cond_arrs], axis=ax)
 
                 # Delete old arrays
-                keys_to_delete = [k for k in self.keys() if cond in k]
+                keys_to_delete = [k for k, v in self.items()
+                                  if cond == v.name]
                 for k in keys_to_delete:
                     self.sites.pop(k, None)
 

--- a/cellst/process.py
+++ b/cellst/process.py
@@ -93,16 +93,22 @@ class Processor(BaseProcessor):
                     track: Track = tuple([]),
                     layout: Tuple[int] = None,
                     border_value: Union[int, float] = 0.,
-                    scaling: float = 1.
                     ) -> Image:
         """"""
-        # TODO: Add scaling
+        # TODO: Add scaling of intensity and dimension
+        # TODO: Add crop
         fil = sitk.TileImageFilter()
         fil.SetLayout(layout)
         fil.SetDefaultPixelValue(border_value)
+
+        #
         stacks = image + mask + track
         images = [cast_sitk(sitk.GetImageFromArray(s), 'sitkUInt16', True)
                   for s in stacks]
+
+        # Rescale intensity
+        rescale = sitk.RescaleIntensityImageFilter()
+        images = [rescale.Execute(i) for i in images]
         out = fil.Execute(images)
 
         return sitk.GetArrayFromImage(out)

--- a/cellst/process.py
+++ b/cellst/process.py
@@ -1,6 +1,6 @@
 import warnings
 from itertools import groupby
-from typing import Union, Collection
+from typing import Union, Collection, Tuple
 
 import numpy as np
 import SimpleITK as sitk
@@ -85,6 +85,27 @@ class Processor(BaseProcessor):
             flat_outputs = [crop_array(fo, crop_vals) for fo in flat_outputs]
 
         return flat_outputs
+
+    @ImageHelper(by_frame=True, as_tuple=True)
+    def tile_images(self,
+                    image: Image = tuple([]),
+                    mask: Mask = tuple([]),
+                    track: Track = tuple([]),
+                    layout: Tuple[int] = None,
+                    border_value: Union[int, float] = 0.,
+                    scaling: float = 1.
+                    ) -> Image:
+        """"""
+        # TODO: Add scaling
+        fil = sitk.TileImageFilter()
+        fil.SetLayout(layout)
+        fil.SetDefaultPixelValue(border_value)
+        stacks = image + mask + track
+        images = [cast_sitk(sitk.GetImageFromArray(s), 'sitkUInt16', True)
+                  for s in stacks]
+        out = fil.Execute(images)
+
+        return sitk.GetArrayFromImage(out)
 
     @ImageHelper(by_frame=True)
     def gaussian_filter(self,

--- a/cellst/utils/info_utils.py
+++ b/cellst/utils/info_utils.py
@@ -378,11 +378,11 @@ def get_split_idxs(arrays: Collection[np.ndarray], axis: int = 0) -> List[int]:
     return split_idxs
 
 
-def split_array(array: np.ndarray, split_idxs: List[int]) -> List[np.ndarray]:
+def split_array(array: np.ndarray, split_idxs: List[int], axis: int = 0) -> List[np.ndarray]:
     """
     """
-    return [n for n in np.split(array, split_idxs, axis=0)
-            if n.shape[0] > 0]
+    return [n for n in np.split(array, split_idxs, axis=axis)
+            if n.shape[axis] > 0]
 
 
 ### Functions for more complicated calculations ###

--- a/cellst/utils/info_utils.py
+++ b/cellst/utils/info_utils.py
@@ -339,13 +339,25 @@ def subset_array(arr: np.ndarray,
     return subset_arr
 
 
-def randomize_array(arr: np.ndarray) -> np.ndarray:
+def randomize_array(arr: Union[Collection[np.ndarray], np.ndarray]
+                    ) -> np.ndarray:
     """"""
+    # If multiple arrays, stack, randomize, unstack
+    _splits = False
+    if isinstance(arr, (list, tuple)):
+        _splits = get_split_idxs(arr)
+        arr = np.vstack(arr)
+
+    # Randomly pull rows from the array
     samples = arr.sum()
     flat_len = len(arr.flatten())
     rand_samples = _RNG.multinomial(samples, np.ones(flat_len) / flat_len)
+    rand_samples = rand_samples.reshape(arr.shape)
 
-    return rand_samples.reshape(arr.shape)
+    if _splits:
+        rand_samples = split_array(rand_samples, _splits)
+
+    return rand_samples
 
 
 def nan_helper(y: np.ndarray) -> np.ndarray:

--- a/cellst/utils/utils.py
+++ b/cellst/utils/utils.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import functools
+import itertools
 import contextlib
 import warnings
 import logging
@@ -311,18 +312,21 @@ class ImageHelper():
             out_shape = next(iter(pass_to_func.values()))[0].shape
             windows = {p: self._multiple_sliding_windows(v)
                        for p, v in pass_to_func.items()}
+            _fv = tuple([])
         else:
             out_shape = next(iter(pass_to_func.values())).shape
             windows = {p: sliding_window_generator(v)
                        for p, v in pass_to_func.items()}
+            _fv = None
 
         # zip_longest in case some stacks aren't found
         # wrapped function should raise an error if this is a problem
-        for fr, win in enumerate(zip_longest(*windows.values())):
+        for fr, win in enumerate(itertools.zip_longest(*windows.values(), fillvalue=_fv)):
             new_win = dict(zip(pass_to_func.keys(), win))
             res = self.func(*calling_cls, **new_win, **kwargs)
             if not fr:
                 # If first frame, make the output array
+                out_shape = (out_shape[0], *res.shape)
                 out = np.empty(out_shape, dtype=res.dtype)
             out[fr, ...] = res
 


### PR DESCRIPTION
This PR introduces some minor changes and fixes to v.0.1.0. 

**New**
- `ExperimentArray` has a new function `add_metric_slots` and a new property `coordinates`. 
- A `tile_images` function is added to `Processor`.
- `ExperimentArray` can calculate filters on all conditions. Useful for example, for thresholding by percentile.
- `watershed_from_markers` would often segment the background. An option has been added to remove that.
- `randomize_array` can also randomize a list of arrays. It combines them, randomizes, then splits them again.

**Bug Fixes**
- `ImageHelper` would pass `None` instead of an empty `tuple` to functions that request tuples. That has been fixed.
- `merge_conditions` would sometimes fail to delete old keys if they were set using `set_conditions`. That has been fixed